### PR TITLE
Add database sampling for generating perf test CSV input

### DIFF
--- a/usecases/finance/ledger/spanner-interactions/data-load/scenario-1-initial-load.jmx
+++ b/usecases/finance/ledger/spanner-interactions/data-load/scenario-1-initial-load.jmx
@@ -5,7 +5,7 @@
       <stringProp name="TestPlan.comments">Populates the user_bal and user_txn table with dummy data</stringProp>
       <boolProp name="TestPlan.functional_mode">false</boolProp>
       <boolProp name="TestPlan.tearDown_on_shutdown">true</boolProp>
-      <boolProp name="TestPlan.serialize_threadgroups">false</boolProp>
+      <boolProp name="TestPlan.serialize_threadgroups">true</boolProp>
       <elementProp name="TestPlan.user_defined_variables" elementType="Arguments" guiclass="ArgumentsPanel" testclass="Arguments" testname="User Defined Variables" enabled="true">
         <collectionProp name="Arguments.arguments">
           <elementProp name="project_id" elementType="Argument">
@@ -167,6 +167,127 @@
           <boolProp name="displaySystemProperties">false</boolProp>
         </DebugSampler>
         <hashTree/>
+      </hashTree>
+      <ThreadGroup guiclass="ThreadGroupGui" testclass="ThreadGroup" testname="Create Sampled CSV Data" enabled="true">
+        <stringProp name="TestPlan.comments">Fetches sampled data from Spanner for the load test</stringProp>
+        <stringProp name="ThreadGroup.on_sample_error">continue</stringProp>
+        <elementProp name="ThreadGroup.main_controller" elementType="LoopController" guiclass="LoopControlPanel" testclass="LoopController" testname="Loop Controller" enabled="true">
+          <boolProp name="LoopController.continue_forever">false</boolProp>
+          <stringProp name="LoopController.loops">1</stringProp>
+        </elementProp>
+        <stringProp name="ThreadGroup.num_threads">1</stringProp>
+        <stringProp name="ThreadGroup.ramp_time">1</stringProp>
+        <boolProp name="ThreadGroup.scheduler">false</boolProp>
+        <stringProp name="ThreadGroup.duration"></stringProp>
+        <stringProp name="ThreadGroup.delay"></stringProp>
+        <boolProp name="ThreadGroup.same_user_on_next_iteration">true</boolProp>
+      </ThreadGroup>
+      <hashTree>
+        <JDBCSampler guiclass="TestBeanGUI" testclass="JDBCSampler" testname="Fetch UserIds" enabled="true">
+          <stringProp name="TestPlan.comments">Create CSV for sample UserIds to be used for perf test.</stringProp>
+          <stringProp name="dataSource">conn_pool</stringProp>
+          <stringProp name="queryType">Select Statement</stringProp>
+          <stringProp name="query">SELECT UserId FROM user_bal_new TABLESAMPLE BERNOULLI (50 PERCENT) limit 100;</stringProp>
+          <stringProp name="queryArguments"></stringProp>
+          <stringProp name="queryArgumentsTypes"></stringProp>
+          <stringProp name="variableNames"></stringProp>
+          <stringProp name="resultVariable"></stringProp>
+          <stringProp name="queryTimeout"></stringProp>
+          <stringProp name="resultSetMaxRows"></stringProp>
+          <stringProp name="resultSetHandler">Store as String</stringProp>
+        </JDBCSampler>
+        <hashTree>
+          <JDBCPreProcessor guiclass="TestBeanGUI" testclass="JDBCPreProcessor" testname="JDBC PreProcessor" enabled="true">
+            <stringProp name="dataSource">conn_pool</stringProp>
+            <stringProp name="queryType">Select Statement</stringProp>
+            <stringProp name="query">SELECT UserId FROM user_bal_new TABLESAMPLE BERNOULLI (50 PERCENT) limit 100;</stringProp>
+            <stringProp name="queryArguments"></stringProp>
+            <stringProp name="queryArgumentsTypes"></stringProp>
+            <stringProp name="variableNames"></stringProp>
+            <stringProp name="resultVariable">resultSet</stringProp>
+            <stringProp name="queryTimeout"></stringProp>
+            <stringProp name="resultSetMaxRows"></stringProp>
+            <stringProp name="resultSetHandler">Store as String</stringProp>
+          </JDBCPreProcessor>
+          <hashTree/>
+          <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="JSR223 PreProcessor" enabled="true">
+            <stringProp name="scriptLanguage">java</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">false</stringProp>
+            <stringProp name="script">resultSet = vars.getObject(&quot;resultSet&quot;);
+StringBuilder result = new StringBuilder();
+
+for (Object row : resultSet ) {
+    iter = row.entrySet().iterator();
+    while (iter.hasNext()) {
+        pair = iter.next();
+        result.append(pair.getValue());
+        result.append(&quot;,&quot;);
+    }
+    result.append(System.getProperty(&quot;line.separator&quot;));
+}
+
+org.apache.commons.io.FileUtils.writeStringToFile(new File(&quot;/Users/manitgupta/userIds.csv&quot;), result.toString(), &quot;UTF-8&quot;);</stringProp>
+          </JSR223PreProcessor>
+          <hashTree/>
+        </hashTree>
+        <JDBCSampler guiclass="TestBeanGUI" testclass="JDBCSampler" testname="Fetch TransactionIds" enabled="true">
+          <stringProp name="TestPlan.comments">Create CSV for sample UserIds, TransactionIds to be used for perf test.</stringProp>
+          <stringProp name="dataSource">conn_pool</stringProp>
+          <stringProp name="queryType">Select Statement</stringProp>
+          <stringProp name="query">SELECT UserId, TransactionId FROM user_txns_new TABLESAMPLE BERNOULLI (50 PERCENT) limit 100;</stringProp>
+          <stringProp name="queryArguments"></stringProp>
+          <stringProp name="queryArgumentsTypes"></stringProp>
+          <stringProp name="variableNames"></stringProp>
+          <stringProp name="resultVariable"></stringProp>
+          <stringProp name="queryTimeout"></stringProp>
+          <stringProp name="resultSetMaxRows"></stringProp>
+          <stringProp name="resultSetHandler">Store as String</stringProp>
+        </JDBCSampler>
+        <hashTree>
+          <JDBCPreProcessor guiclass="TestBeanGUI" testclass="JDBCPreProcessor" testname="JDBC PreProcessor" enabled="true">
+            <stringProp name="dataSource">conn_pool</stringProp>
+            <stringProp name="queryType">Select Statement</stringProp>
+            <stringProp name="query">SELECT UserId, TransactionId FROM user_txns_new TABLESAMPLE BERNOULLI (50 PERCENT) limit 100;</stringProp>
+            <stringProp name="queryArguments"></stringProp>
+            <stringProp name="queryArgumentsTypes"></stringProp>
+            <stringProp name="variableNames"></stringProp>
+            <stringProp name="resultVariable">resultSet</stringProp>
+            <stringProp name="queryTimeout"></stringProp>
+            <stringProp name="resultSetMaxRows"></stringProp>
+            <stringProp name="resultSetHandler">Store as String</stringProp>
+          </JDBCPreProcessor>
+          <hashTree/>
+          <JSR223PreProcessor guiclass="TestBeanGUI" testclass="JSR223PreProcessor" testname="JSR223 PreProcessor" enabled="true">
+            <stringProp name="scriptLanguage">groovy</stringProp>
+            <stringProp name="parameters"></stringProp>
+            <stringProp name="filename"></stringProp>
+            <stringProp name="cacheKey">true</stringProp>
+            <stringProp name="script">resultSet = vars.getObject(&quot;resultSet&quot;)
+result = new StringBuilder()
+
+def randomRow = resultSet.get(org.apache.commons.lang3.RandomUtils.nextInt(0,resultSet.size()))
+
+randomRow.each { k, v -&gt; 
+    result.append(&quot;${k}&quot;).append(&quot;,&quot;)
+}
+result.append(System.getProperty(&quot;line.separator&quot;))
+
+for (Object row : resultSet ) {
+    iter = row.entrySet().iterator()
+    while (iter.hasNext()) {
+        pair = iter.next()
+        result.append(pair.getValue())
+        result.append(&quot;,&quot;)
+    }
+    result.append(System.getProperty(&quot;line.separator&quot;))
+}
+
+org.apache.commons.io.FileUtils.writeStringToFile(new File(&quot;/Users/manitgupta/transactionIds.csv&quot;), result.toString(), &quot;UTF-8&quot;)</stringProp>
+          </JSR223PreProcessor>
+          <hashTree/>
+        </hashTree>
       </hashTree>
       <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="true">
         <boolProp name="ResultCollector.error_logging">false</boolProp>


### PR DESCRIPTION
Adds a new thread group to sample the data populated in the Spanner tables and dump it into a CSV file. This will be used as input to the Perf test.